### PR TITLE
first commit; updated README.md to 0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A thin Clojure wrapper around OWLAPI, and some utilities for working with RDF/XM
 
 Add `ontodev/owlapi` to your [Leiningen](http://leiningen.org/) project dependencies:
 
-    [ontodev/owlapi "0.3.0"]
+    [ontodev/owlapi "0.3.2"]
 
 ### OWLAPI
 


### PR DESCRIPTION
I only changed the version number that is used in the Leinengen dependencies; it said 0.3.0; I suppose it should be 0.3.2.
